### PR TITLE
More speed

### DIFF
--- a/maserol/model.py
+++ b/maserol/model.py
@@ -20,7 +20,7 @@ def phi(Phisum, Rtot, L0, KxStar, Kav):
     return Phisum
 
 
-def lBnd(L0: float, KxStar, Rtot, Kav):
+def phi_solve(L0: float, KxStar, Rtot, Kav):
     """
     The main function. Generate all info for heterogenenous binding case
     L0: concentration of ligand complexes.
@@ -34,7 +34,7 @@ def lBnd(L0: float, KxStar, Rtot, Kav):
         Phisum_n = phi(Phisum, Rtot, L0, KxStar, Kav)
         Phisum = Phisum_n
 
-    return L0 / KxStar * ((1.0 + Phisum) ** 2 - 1.0)
+    return Phisum
 
 
 def human_affinity():

--- a/maserol/model.py
+++ b/maserol/model.py
@@ -2,39 +2,9 @@
 
 from os.path import join, dirname
 import pandas as pd
-from jax.config import config
-import jax.numpy as jnp
 
 
 path_here = dirname(dirname(__file__))
-
-
-config.update("jax_enable_x64", True)
-
-
-def phi(Phisum, Rtot, L0, KxStar, Kav):
-    Phisum = jnp.expand_dims(Phisum, 1)
-    Req = Rtot / (1.0 + 2.0 * L0 * Kav * (1.0 + Phisum))
-    assert Req.shape == Rtot.shape
-    Phisum = jnp.einsum("ij,kil->kl", Kav * KxStar, Req)
-    return Phisum
-
-
-def phi_solve(L0: float, KxStar, Rtot, Kav):
-    """
-    The main function. Generate all info for heterogenenous binding case
-    L0: concentration of ligand complexes.
-    KxStar: detailed balance-corrected Kx.
-    Rtot: numbers of each receptor appearing on the cell.
-    Kav: a matrix of Ka values. row = ligands, col = receptors
-    """
-    Phisum = jnp.zeros((Rtot.shape[0], Rtot.shape[2]))
-
-    for ii in range(5):
-        Phisum_n = phi(Phisum, Rtot, L0, KxStar, Kav)
-        Phisum = Phisum_n
-
-    return Phisum
 
 
 def human_affinity():

--- a/maserol/predictAbundKa.py
+++ b/maserol/predictAbundKa.py
@@ -9,20 +9,29 @@ import jax.numpy as jnp
 from scipy.optimize import minimize
 from jax import value_and_grad, jvp, jit
 from jax.config import config
-from .model import phi_solve
 from scipy.stats import pearsonr
+from tensorly.decomposition import non_negative_parafac
 
-config.update('jax_log_compiles', True)
+
+config.update("jax_enable_x64", True)
+
 
 def initial_AbundKa(cube, n_ab=1):
     """
-    generate abundance and Ka matrices from random values
+    generate abundance and Ka matrices from linear analysis
     cube.shape == n_subj * n_rec * n_Ag
     """
-    R_subj_guess = np.random.lognormal(size=(cube.shape[0], n_ab))
-    R_Ag_guess = np.random.lognormal(size=(cube.shape[2], n_ab))
-    Ka_guess = np.random.lognormal(12.0, size=(cube.shape[1], n_ab))
-    return R_subj_guess, R_Ag_guess, Ka_guess
+    # TODO: Add masking
+    outt = non_negative_parafac(np.nan_to_num(cube), rank=n_ab)
+    return outt.factors
+
+
+def phi(Phisum, Rtot, L0, KxStar, Kav):
+    temp = jnp.einsum("jl,ijk->ilkj", Kav, 1.0 + Phisum)
+    Req = Rtot[:, :, :, np.newaxis] / (1.0 + 2.0 * L0 * temp)
+    Phisum_n = jnp.einsum("jl,ilkj->ijk", Kav * KxStar, Req)
+    assert Phisum_n.shape == Phisum.shape
+    return Phisum_n
 
 
 def infer_Lbound(R_subj, R_Ag, Ka, L0=1e-9, KxStar=1e-12):
@@ -31,19 +40,16 @@ def infer_Lbound(R_subj, R_Ag, Ka, L0=1e-9, KxStar=1e-12):
     and ant x sub pair and store in matrix same size as flatten
     """
     Phisum = jnp.zeros((R_subj.shape[0], Ka.shape[0], R_Ag.shape[0]))
-    # Lbound_guess = 6x1638
-    RR = jnp.einsum("ij,kj->ijk", R_subj, R_Ag)
+    Rtot = jnp.einsum("ij,kj->ijk", R_subj, R_Ag)
 
-    for jj in range(Phisum.shape[1]):
-        Phisum = Phisum.at[:, jj, :].set(phi_solve(L0, KxStar, RR, Ka[jj, :, np.newaxis]))
+    for ii in range(5):
+        Phisum_n = phi(Phisum, Rtot, L0, KxStar, Ka)
+        Phisum = Phisum_n
 
     return L0 / KxStar * ((1.0 + Phisum) ** 2 - 1.0)
 
 
-def model_lossfunc(x, cube, L0=1e-9, KxStar=1e-12):
-    """
-        Loss function, comparing model output and flattened tensor
-    """
+def reshapeParams(x, cube):
     # unflatten to three matrices
     n_subj, n_rec, n_Ag = cube.shape
     n_ab = int(len(x) / np.sum(cube.shape))
@@ -51,7 +57,19 @@ def model_lossfunc(x, cube, L0=1e-9, KxStar=1e-12):
     R_subj = x[0:(n_subj * n_ab)].reshape(n_subj, n_ab)
     R_Ag = x[(n_subj * n_ab):((n_subj + n_Ag) * n_ab)].reshape(n_Ag, n_ab)
     Ka = x[(n_subj + n_Ag) * n_ab:(n_subj + n_Ag + n_rec) * n_ab].reshape(n_rec, n_ab)
+    return R_subj, R_Ag, Ka
 
+
+def flattenParams(R_subj, R_Ag, Ka):
+    """ Flatten into a parameter vector. """
+    return np.concatenate((R_subj.flatten(), R_Ag.flatten(), Ka.flatten()))
+
+
+def model_lossfunc(x, cube, L0=1e-9, KxStar=1e-12):
+    """
+        Loss function, comparing model output and flattened tensor
+    """
+    R_subj, R_Ag, Ka = reshapeParams(x, cube)
     Lbound = infer_Lbound(R_subj, R_Ag, Ka, L0=L0, KxStar=KxStar)
     return jnp.linalg.norm(jnp.nan_to_num(Lbound - cube))
 
@@ -61,34 +79,22 @@ def optimize_lossfunc(cube, n_ab=1, maxiter=100):
         Optimization method to minimize model_lossfunc output
     """
     R_subj_guess, R_Ag_guess, Ka_guess = initial_AbundKa(cube, n_ab=n_ab)
-    x0 = np.concatenate((R_subj_guess.flatten(), R_Ag_guess.flatten(), Ka_guess.flatten()))
+    x0 = flattenParams(R_subj_guess, R_Ag_guess, Ka_guess)
 
     func = jit(value_and_grad(model_lossfunc))
     opts = {"verbose": 1, 'maxiter': maxiter}
-    bnd = [(1e-9, np.inf)] * x0.size
+    bnd = [(0.0, np.inf)] * x0.size
 
     def hvp(x, p, *args):
         return jvp(lambda xx: func(xx, *args)[1], (x,), (p,))[1]
 
-    def funcc(*args):
-        a, b = func(*args)
-        return a, np.array(b)
-
     print("")
-    opt = minimize(funcc, x0, method="trust-constr", args=(cube, 1e-9, 1e-12), hessp=hvp, jac=True, bounds=bnd, options=opts)
+    opt = minimize(func, x0, method="trust-constr", args=(cube, 1e-9, 1e-12), hessp=hvp, jac=True, bounds=bnd, options=opts)
     print(opt.fun)
 
+    R_subj, R_Ag, Ka = reshapeParams(opt.x, cube)
+
     return opt.x[:, np.newaxis]
-
-
-def opt_to_matrices(cube, RKa_opt):
-    n_subj, n_rec, n_Ag = cube.shape
-    n_ab = int(len(RKa_opt) / np.sum(cube.shape))
-
-    R_subj = RKa_opt[0:(n_subj * n_ab)].reshape(n_subj, n_ab)
-    R_Ag = RKa_opt[(n_subj * n_ab):((n_subj + n_Ag) * n_ab)].reshape(n_Ag, n_ab)
-    Ka = RKa_opt[(n_subj + n_Ag) * n_ab:(n_subj + n_Ag + n_rec) * n_ab].reshape(n_rec, n_ab)
-    return R_subj, R_Ag, Ka
 
 
 def plot_correlation_heatmap(ax, RKa_opt, cube, rec_names, ant_names):
@@ -98,7 +104,7 @@ def plot_correlation_heatmap(ax, RKa_opt, cube, rec_names, ant_names):
     R_subj, R_Ag, Ka, L0=L0, KxStar=KxStar
     """
 
-    R_subj, R_Ag, Ka = opt_to_matrices(cube, RKa_opt)
+    R_subj, R_Ag, Ka = reshapeParams(RKa_opt, cube)
     Lbound_model = infer_Lbound(R_subj, R_Ag, Ka, L0=1e-9, KxStar=1e-12)
 
     coeff = np.zeros([cube.shape[1], cube.shape[2]])

--- a/maserol/test/test_predictAbundKa.py
+++ b/maserol/test/test_predictAbundKa.py
@@ -13,4 +13,4 @@ def test_SpaceX(n_ab):
     assert RKa_opt > 0.0
     assert np.isfinite(RKa_opt)
 
-    optimize_lossfunc(cube, n_ab=n_ab, maxiter=100)
+    optimize_lossfunc(cube, n_ab=n_ab, maxiter=200)

--- a/maserol/test/test_predictAbundKa.py
+++ b/maserol/test/test_predictAbundKa.py
@@ -13,4 +13,4 @@ def test_SpaceX(n_ab):
     assert RKa_opt > 0.0
     assert np.isfinite(RKa_opt)
 
-    optimize_lossfunc(cube, n_ab=n_ab, maxiter=2)
+    optimize_lossfunc(cube, n_ab=n_ab, maxiter=100)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pandoc-tablenos==2.3.0
 matplotlib==3.5.1
 jax==0.2.26
 jaxlib
-jaxopt
 seaborn==0.11.2
 svgutils==0.3.4
 tensorly==0.7.0


### PR DESCRIPTION
This makes four overall changes:

- The fixed point jaxopt operation is really just a loop. By making this ourselves we can jit the function speeding it up a lot.
- The entire tensor is now solved at once, rather than each detection.
- An initial pass at nn_cp based initialization.
- I made two reshaping functions to/from an unknown parameter vector so these can be reused.

Fitting is now just fast.