### PR TITLE
add distribution unit test parameter forward-backward

### DIFF
--- a/maserol/core.py
+++ b/maserol/core.py
@@ -138,7 +138,7 @@ def modelLoss(log_x: np.ndarray, cube: Union[xr.DataArray, np.ndarray], Ka: np.n
     Lbound = inferLbound(cube, *(params + ([] if fitKa else [Ka])), L0=L0, KxStar=KxStar, FcIdx=FcIdx)
     scaling_factor = log_x[-1]
 
-    return np.nan_to_num(np.log(cube) - np.log(Lbound) + scaling_factor).flatten()
+    return np.nan_to_num(np.log(cube) - np.log(Lbound) + scaling_factor, neginf=0).flatten()
 
 
 def optimizeLoss(

--- a/maserol/test/test_core.py
+++ b/maserol/test/test_core.py
@@ -142,14 +142,15 @@ def generate_random_numbers(n, m):
 
 @pytest.mark.parametrize("n_samp", [8, 32, 256])
 @pytest.mark.parametrize("L0", [1e-9, 1e-5])
-def test_forward_backward_simple(n_samp, L0):
+@pytest.mark.parametrize("rcp_high", [1e5, 1e6])
+def test_forward_backward_simple(n_samp, L0, rcp_high):
     # subset of HIgGFs
     ab_types = ["IgG1", "IgG2", "IgG3", "IgG3f"]
     # subset of ['IgG1', 'IgG2', 'IgG3', 'IgG4', 'FcgRI', 'FcgRIIA-131H', 'FcgRIIA-131R',
     #        'FcgRIIB-232I', 'FcgRIIIA-158F', 'FcgRIIIA-158V', 'FcgRIIIB', 'C1q']
     rcp = ['IgG1', 'IgG2', 'IgG3', 'FcgRIIB-232I', 'FcgRIIIA-158F', 'FcgRIIIA-158V', 'FcgRIIIB'] 
     KxStar = 1e-12
-    Rtot_np = np.random.rand(n_samp, len(ab_types), 1) * 1e5
+    Rtot_np = np.random.uniform(high=rcp_high, size=(n_samp, len(ab_types), 1))
     Rtot = xr.DataArray(Rtot_np, [np.arange(Rtot_np.shape[0]), list(ab_types), np.arange(Rtot_np.shape[2])], ["Sample", "Antibody", "Antigen"],)
     cube = xr.DataArray(np.zeros((Rtot.shape[0], len(rcp), Rtot.shape[2])), (Rtot.Sample.values, rcp, Rtot.Antigen.values),  ("Sample", "Receptor", "Antigen"))
     Ka = assembleKav(cube, ab_types)

--- a/maserol/test/test_core.py
+++ b/maserol/test/test_core.py
@@ -140,9 +140,9 @@ def generate_random_numbers(n, m):
     return np.diff(random_numbers)
 
 
-@pytest.mark.parametrize("n_samp", [8, 32, 256])
+@pytest.mark.parametrize("n_samp", [10, 100, 1000])
 @pytest.mark.parametrize("L0", [1e-9, 1e-5])
-@pytest.mark.parametrize("rcp_high", [1e5, 1e6])
+@pytest.mark.parametrize("rcp_high", [1e2, 1e5, 1e8])
 def test_forward_backward_simple(n_samp, L0, rcp_high):
     # subset of HIgGFs
     ab_types = ["IgG1", "IgG2", "IgG3", "IgG3f"]


### PR DESCRIPTION
- Remove scaling factor. If we indeed believe that we need a linear degree of freedom for all Lbound, we should instead just find a distribution for Lbound that works and then normalize Lbound before optimization to match this distribution. This leads to much better performance.
- Scale the starting distribution of Rtot based on the distribution of Lbound. 
- Replace the custom newton-raphson method for root finding with scipy.optimize.newton. I found this performs better on datasets which may have numerical instability due to large starting distributions. 